### PR TITLE
Solucionado error seguridad configuración

### DIFF
--- a/src/AppBundle/Controller/ConfigWebController.php
+++ b/src/AppBundle/Controller/ConfigWebController.php
@@ -16,6 +16,9 @@ class ConfigWebController extends Controller
      */
     public function dashboardAction(Request $request,User $current_user)
     {
+        if($this->getUser()->getId() != $current_user->getId())
+            return $this->redirectToRoute('index_web');
+
         $optionsConvocatory = Array(
             "convocatories" => $this->get('app.convocatoriesHelper')->prepareOptions(),
         );


### PR DESCRIPTION
Se ha solucionado un error de seguridad que consistía en
que un usuario puede entrar a configurar parámetros de la web
de otro usuario,