### PR TITLE
Error null current_convocatory

### DIFF
--- a/src/AppBundle/Services/UsersHelper.php
+++ b/src/AppBundle/Services/UsersHelper.php
@@ -44,7 +44,8 @@ class UsersHelper
 
         $teachers  = Array();
         $teacherResult = $teacherRepository->getUsersValid();
-        if($convocatory) {
+
+        if($convocatoryRepository->findBy(array('id' => $convocatory)) != null) {
             foreach ($teacherResult as $teacher) {
                 array_push(
                     $teachers, new TeacherData(


### PR DESCRIPTION
Se ha solucionado el problema de que cuando accedes a la vista
de inicio y no tienes current_user relleno o no existe la
convocatoria, salte una exception.