### PR TITLE
Solucionado error ArrayIds

### DIFF
--- a/src/AppBundle/Repository/StudentRepository.php
+++ b/src/AppBundle/Repository/StudentRepository.php
@@ -35,7 +35,9 @@ class StudentRepository extends \Doctrine\ORM\EntityRepository
 
         $arrayIds = $this->arrayIdsToString($q2b->getQuery()->getArrayResult());
 
-        return $this->getStudentsNotIN($convocatory, $arrayIds);
+        if(count($arrayIds) > 0)
+            return $this->getStudentsNotIN($convocatory, $arrayIds);
+        return $this->getAllStudentsConvocatory($convocatory);
     }
 
     public function getStudentsNotIN($convocatory, $arrayIds)


### PR DESCRIPTION
Saltaba un error cuando añadias una nueva asignación al pinchar
sobre un el botón rojo de los alumnos en inicio.