### PR TITLE
Se ha solucionado error null en convocatoria

### DIFF
--- a/src/AppBundle/Services/FunctionsHelper.php
+++ b/src/AppBundle/Services/FunctionsHelper.php
@@ -23,7 +23,7 @@ class FunctionsHelper
 
         /** @var ConvocatoryRepository $convocatoryRepository */
         $convocatoryRepository = $this->em->getRepository("AppBundle:Convocatory");
-        $current_convocatory = $convocatoryRepository->find($convocatory);
+        $current_convocatory = $convocatory ? $convocatoryRepository->find($convocatory): false;
 
         if($current_convocatory){
             return $current_convocatory->getSchoolYear()->getCourse() == $schoolYearRepository->getLastCourse()->getCourse();


### PR DESCRIPTION
El problema se ha detectado al crear cualquer registro 	que
necesitara que la convocatoria estubiera elegida. Al no
estarlo, lanzaba una exception.