### PR TITLE
Error en editar student

### DIFF
--- a/src/AppBundle/Controller/PanelStudentController.php
+++ b/src/AppBundle/Controller/PanelStudentController.php
@@ -162,7 +162,8 @@ class PanelStudentController extends Controller
 
         /** @var Convocatory $convocatory */
         foreach ($convocatoriesHelper->getAllConvocatories() as $convocatory) {
-            $convocatories[$convocatory->__toString()] = $convocatory;
+            if($current_convocatory == $convocatory->getId())
+                $convocatories[$convocatory->__toString()] = $convocatory;
         }
 
         $options = array(


### PR DESCRIPTION
Se ha solucionado error en el select de editar student ya que
se muestraba en el select de (convocatory), todas las
convocatorias cuando sólo se debe mostrar en la que estás
administrando(la actual)